### PR TITLE
Hide TOC on mousedown overlay

### DIFF
--- a/src/lib/components/Overlay.svelte
+++ b/src/lib/components/Overlay.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
   import {onMount} from 'svelte';
+  import {showTOC} from '$lib/store';
+
+  const hideOverlay = () => {
+    $showTOC = false;
+  };
 
   onMount(() => {
     document.body.style.overflow = 'hidden';
@@ -7,4 +12,5 @@
     return () => {document.body.style.overflow = '';};
   });
 </script>
-<div class="fixed w-full h-full backdrop-blur-lg bg-[#333a] z-10" />
+<div class="fixed w-full h-full backdrop-blur-lg bg-[#333a] z-10"
+  on:mousedown={hideOverlay} role="button" aria-pressed="false" aria-label="Hide TOC" tabindex="0" />

--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -29,15 +29,7 @@ I don't know why, but setting max-height on 'aside' shows bad strange behavior.
 The scrollable height is not big enough to show the front child 'li' elements.
 -->
 <aside class={`w-[300px] overflow-hidden hidden mt-10 self-start md:!flex md:sticky md:top-14 flex-col justify-center items-center p-3
-  ${$showTOC ? '!w-[94vw] pt-2 pb-6 z-20 !flex fixed top-14 left-[50%] translate-x-[-50%] border-2 border-neutral-300 bg-neutral-50 shadow-lg rounded-md' : ''}`}>
-  {#if $showTOC}
-    <div class="flex self-end justify-items-end items-start">
-      <button class="flex items-center justify-start p-1 font-bold text-lg" aria-label="Close TOC"
-        on:click={() => {$showTOC = false;}}>
-        Close
-      </button>
-    </div>
-  {/if}
+  ${$showTOC ? '!w-[94vw] py-6 z-20 !flex fixed top-14 left-[50%] translate-x-[-50%] border-2 border-neutral-300 bg-neutral-50 shadow-lg rounded-md' : ''}`}>
   <ul class="w-full max-h-[80vh] overflow-auto">
     {#each data as item, index}
       <li title={item.text}


### PR DESCRIPTION
- Hide TOC and Overlay components when user mousedown on Overlay
- Delete 'Close' button from TOC