### PR TITLE
Add google site verification meta tag at index.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,9 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
+		<!-- [TODO] For portability I can erase the following elements and inject them from index.ts when building? -->
 		<title>dlguswo333's Blog</title>
+		<meta name="google-site-verification" content="GIhlBkE7qu5AWLVmQ4w2lBcxEw-AumQhdQf_2zR2X4s" />
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div id="root">%sveltekit.body%</div>


### PR DESCRIPTION
For portability (e.g. others fork or I use it for different blog-like webpages),
Later I can define those personal contents from `index.ts` and inject them while building.
Refer to https://github.com/vbenjs/vite-plugin-html .