### PR TITLE
[#20] Fix heading highlight not shown initial toc render small screen

### DIFF
--- a/src/lib/components/MainSection.svelte
+++ b/src/lib/components/MainSection.svelte
@@ -75,6 +75,11 @@
       document.removeEventListener('scroll', onScroll);
     };
   });
+
+  $: if ($tocItemHeight && mainHtml) {
+    const headings = [...mainHtml.querySelectorAll('h1,h2,h3,h4')];
+    updateHeadingHighlight(headings);
+  }
 </script>
 <!--
 @component


### PR DESCRIPTION
The bug was due to that on small screens, TOC items does not render default.
Then `tocItemHeight` store will not be set, and if users click TOC button,
even if `tocItemHeight` is now set, scroll event does not fire.

Put it simply, `tocItemHeight` and scroll event are necessary conditions to render highlight.
If `tocItemHeight` is updated, Svelte will react to the update and update heading highlight.