### PR TITLE
Specify `trailingSlash` `always` option in route layout

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,2 @@
 export const prerender = true;
+export const trailingSlash = 'always';


### PR DESCRIPTION
Somehow, I did not specify this option.
Within Github Pages, it's better to set the option to `always` since Github Pages results in `/a` 404 error when `/a.html` exists but `/a/index.html`.
Frankly My blog emits 404 error when visiting the path `/about/`.

Check out this highly valuable guide repository: https://github.com/slorber/trailing-slash-guide
