### PR TITLE
[#33] Fix href links to have trailing slash

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -10,7 +10,7 @@
   class={'flex flex-col border-2 rounded-md transition px-4 py-2 border-gray-300 hover:border-teal-400 hover:bg-teal-50 dark:border-gray-400 dark:hover:bg-teal-900 dark:hover:border-teal-500'}>
   <div class="flex flex-row items-center justify-between mb-1">
     <span>
-      <a href={`/post/${post.date.split('-')[0]}/${post.id}`} class="text-cyan-400 visited:text-purple-600">
+      <a href={`/post/${post.date.split('-')[0]}/${post.id}/`} class="text-cyan-400 visited:text-purple-600">
         <h1 class="inline-block font-bold text-lg mr-2 underline">{post.title}</h1>
       </a>
     </span>

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -17,6 +17,6 @@
     {/each}
   </ul>
   <Pagination curIndex={curIndex} maxIndex={maxIndex} maxDisplaySize={6}
-    getHref={(num) => num === 1 ? '/' : `/posts/${num}`}
+    getHref={(num) => num === 1 ? '/' : `/posts/${num}/`}
   />
 </MainSection>

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -21,8 +21,8 @@
     {/if}
   </div>
   <div class="flex flex-row items-center">
-    <HeaderLink href='/categories' text='Categories' />
-    <HeaderLink href='/tags' text='Tags' />
-    <HeaderLink href='/about' text='About' />
+    <HeaderLink href='/categories/' text='Categories' />
+    <HeaderLink href='/tags/' text='Tags' />
+    <HeaderLink href='/about/' text='About' />
   </div>
 </header>

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -13,7 +13,7 @@
         <ul>
           {#each posts as post}
             <li class="flex flex-col md:flex-row justify-between md:items-center px-2 border-2 rounded-md border-transparent hover:border-gray-200">
-              <a href={`/post/${post.date.split('-')[0]}/${post.id}`}
+              <a href={`/post/${post.date.split('-')[0]}/${post.id}/`}
                 class="text-cyan-400 visited:text-purple-600 max-w-full py-1 text-ellipsis whitespace-nowrap overflow-hidden">
                 {post.title}
               </a>

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -13,7 +13,7 @@
         <ul>
           {#each posts as post}
             <li class="flex flex-col md:flex-row justify-between md:items-center px-2 border-2 rounded-md border-transparent hover:border-gray-200">
-              <a href={`/post/${post.date.split('-')[0]}/${post.id}`}
+              <a href={`/post/${post.date.split('-')[0]}/${post.id}/`}
                 class="text-cyan-400 visited:text-purple-600 max-w-full py-1 text-ellipsis whitespace-nowrap overflow-hidden">
                 {post.title}
               </a>


### PR DESCRIPTION
Since #33 my blog redirects from URLs without trailing slashes to URLs with trailing slashes.
But since then even if users click on the URLs without trailing slashes the original links do not appear on browser history thus `:visited` css rules do not apply on them.
I could not find any reliable sources for that original URLs that 301 redirect user agents do not appear on browser history, but anyway, I would better synchronize them.