### PR TITLE
[#48] Show TOC in categories and tags pages

### DIFF
--- a/markdown/2021/08-12-en-customize-windows-powershell.md
+++ b/markdown/2021/08-12-en-customize-windows-powershell.md
@@ -4,7 +4,7 @@ toc: true
 editedDate: 2022-06-18
 title: "Customize Windows Powershell"
 category: ["Programming"]
-tags: [Windows, Powershell, Git]
+tags: [windows, powershell, git]
 author:
   - 이현재
 ---

--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -36,8 +36,8 @@ The scrollable height is not big enough to show the front child 'li' elements.
 -->
 <aside class={`w-[300px] overflow-hidden hidden mt-10 self-start md:!flex md:sticky md:top-14 flex-col justify-center items-center p-3
   ${$showTOC ? '!w-[94vw] py-6 z-20 !flex fixed top-14 left-[50%] translate-x-[-50%] border-2 border-neutral-300 bg-neutral-50 shadow-lg rounded-md dark:bg-neutral-800' : ''}`}>
-  <div class="relative w-full">
-    <ul class="max-h-[80vh] overflow-auto">
+  <div class="relative w-full overflow-auto">
+    <ul class="max-h-[80vh]">
       {#each data as item}
         <!-- I would like to bind the height for the first li only, but do not know easy way to do that. -->
         <li title={item.text} bind:offsetHeight={$tocItemHeight}

--- a/src/routes/categories/+page.server.ts
+++ b/src/routes/categories/+page.server.ts
@@ -1,5 +1,5 @@
 import crawlPosts from '$lib/crawlPosts';
-import type {PostMetadata} from '$lib/types';
+import type {PostMetadata, TOCItem} from '$lib/types';
 
 export const load = async () => {
   // Since posts are crawled in time order,
@@ -17,7 +17,15 @@ export const load = async () => {
     }
   });
   const sortedCategories = Object.keys(categories).sort();
+
+  const tocData: TOCItem[] = sortedCategories.map(category => ({
+    id: category,
+    text: category,
+    depth: 1,
+  }));
+
   return {
     categories: sortedCategories.map(category => ({category, posts: categories[category]})),
+    tocData,
   };
 };

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import MainSection from '$lib/components/MainSection.svelte';
+  import TOC from '$lib/components/TOC.svelte';
 
   export let data;
 </script>
-<div class="flex flex-row flex-grow justify-center p-2 lg:p-0">
-  <MainSection>
+<div class="flex flex-row flex-grow justify-center p-2 lg:p-0 lg:pr-[300px]">
+  {#if data.tocData}
+    <TOC data={data.tocData} />
+  {/if}
+  <MainSection tocDataExists={!!data.tocData.length}>
     {#each data.categories as {category, posts}}
       <section class="mb-8 w-full">
         <h1 id={category} class="text-3xl font-bold pb-2 mb-3 border-b-2 scroll-mt-[50px]">

--- a/src/routes/tags/+page.server.ts
+++ b/src/routes/tags/+page.server.ts
@@ -22,9 +22,9 @@ export const load = async () => {
     a.toLowerCase().localeCompare(b.toLowerCase())
   );
 
-  const tocData: TOCItem[] = sortedTags.map(category => ({
-    id: category,
-    text: category,
+  const tocData: TOCItem[] = sortedTags.map(tag => ({
+    id: tag,
+    text: tag,
     depth: 1,
   }));
 

--- a/src/routes/tags/+page.server.ts
+++ b/src/routes/tags/+page.server.ts
@@ -1,5 +1,5 @@
 import crawlPosts from '$lib/crawlPosts';
-import type {PostMetadata} from '$lib/types';
+import type {PostMetadata, TOCItem} from '$lib/types';
 
 export const load = async () => {
   // Since posts are crawled in time order,
@@ -19,7 +19,15 @@ export const load = async () => {
     });
   });
   const sortedTags = Object.keys(tags).sort();
+
+  const tocData: TOCItem[] = sortedTags.map(category => ({
+    id: category,
+    text: category,
+    depth: 1,
+  }));
+
   return {
     tags: sortedTags.map(tag => ({tag, posts: tags[tag]})),
+    tocData,
   };
 };

--- a/src/routes/tags/+page.server.ts
+++ b/src/routes/tags/+page.server.ts
@@ -18,7 +18,9 @@ export const load = async () => {
       }
     });
   });
-  const sortedTags = Object.keys(tags).sort();
+  const sortedTags = Object.keys(tags).sort((a, b) => 
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
 
   const tocData: TOCItem[] = sortedTags.map(category => ({
     id: category,

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import MainSection from '$lib/components/MainSection.svelte';
+  import TOC from '$lib/components/TOC.svelte';
 
   export let data;
 </script>
-<div class="flex flex-row flex-grow justify-center p-2 lg:p-0">
-  <MainSection>
+<div class="flex flex-row flex-grow justify-center p-2 lg:p-0 lg:pr-[300px]">
+  {#if data.tocData}
+    <TOC data={data.tocData} />
+  {/if}
+  <MainSection tocDataExists={!!data.tocData.length}>
     {#each data.tags as {tag, posts}}
       <section class="mb-8 w-full">
         <h1 id={tag} class="text-3xl font-bold pb-2 mb-3 border-b-2 scroll-mt-[50px]">


### PR DESCRIPTION
Closes #48 .

- Show TOC in categories page.
- Show TOC In tags page.
- Sort tags in case insensitive way in tags page.
- Change some tag cases in a post.
  There were 'windows' and 'Windows' tags.
- Fix highlight in TOC not being scrolled in synchronous with the `ul` tag.