### PR TITLE
Use link tag to load fonts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,7 +1,5 @@
 @import "./prism-dracula.css";
 
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Noto+Sans+KR:wght@100..900&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app.html
+++ b/src/app.html
@@ -2,6 +2,9 @@
 <html lang="%lang%">
 	<head>
 		<meta charset="utf-8" />
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Noto+Sans+KR:wght@100..900">
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%


### PR DESCRIPTION
Everytime I visit my blog I noticed there is a font loading going on and webpage flickers; I didn't like it.
But I was like: 'The fonts are loading lazily, that is good for performance'.
But My page is fast enough and flickering keeps getting in my eyes.

I changed from `@import` to `<link>` to load fonts. [Google says](https://web.dev/articles/font-best-practices) that link tags may load faster.
![image](https://github.com/user-attachments/assets/3447e7e4-7fc7-44af-aa11-a9c5ced86b3d)

Also I removed `"display=swap"` string from the href attribute. They say swap option tells browser it is safe to load font lazily and *swap* the fonts.
https://css-tricks.com/almanac/properties/f/font-display/#values

Now page shows empty screen for a while but it feels more smooth to me.
If I don't like it, I can revert it later.