### PR TITLE
Fix `ColorThemeButton` flicker on browser refresh

### DIFF
--- a/src/lib/components/ColorThemeButton.svelte
+++ b/src/lib/components/ColorThemeButton.svelte
@@ -1,40 +1,29 @@
 <script lang="ts">
-  import type {ColorTheme} from '$lib/types';
-  import {getCurrentTheme, toggleTheme} from '$lib/colorTheme';
-  import {browser} from '$app/environment';
-  import {currentTheme as themeStore} from '$lib/store';
-
-  let currentTheme: ColorTheme | null = browser ? getCurrentTheme() : null;
-
-  $: $themeStore = currentTheme;
+  import {toggleTheme} from '$lib/colorTheme';
 </script>
 <button type="button" title="Toggle color theme"
   class='group'
   on:click={() => {
-    currentTheme = getCurrentTheme() === 'light' ? 'dark' : 'light';
     toggleTheme();
   }}>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"
-    class="h-8 w-8 transition">
-    {#if currentTheme === 'dark'}
-      <rect x="3" y="3" width="94" height="94" stroke-width="6" rx="16" ry="16"
-        class='stroke-gray-400 fill-none group-hover:fill-gray-50'/>
-      <circle cx="50" cy="50" r="20" class="stroke-gray-400 fill-none group-hover:stroke-none group-hover:fill-amber-500" stroke-width="6" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(45, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(90, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(135, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(180, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(225, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(270, 50, 50)" />
-      <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(315, 50, 50)" />
-    {:else if currentTheme === 'light'}
-      <rect x="3" y="3" width="94" height="94" stroke-width="6" rx="16" ry="16"
-        class='stroke-black fill-none group-hover:fill-gray-700'/>
-      <path d="M 50 20 A 30 30 0 1 1 24.02 65 A 30 30 1 0 0 50 20 Z" stroke-linecap="round" class="fill-none stroke-black group-hover:fill-yellow-300 group-hover:stroke-none" stroke-width="6" />
-    {:else}
-      <rect x="3" y="3" width="94" height="94" stroke-width="6" rx="16" ry="16"
-        class='stroke-gray-600 fill-none'/>
-    {/if}
+    class="h-8 w-8 transition dark:hidden">
+    <rect x="3" y="3" width="94" height="94" stroke-width="6" rx="16" ry="16"
+      class='stroke-black fill-none group-hover:fill-gray-700'/>
+    <path d="M 50 20 A 30 30 0 1 1 24.02 65 A 30 30 1 0 0 50 20 Z" stroke-linecap="round" class="fill-none stroke-black group-hover:fill-yellow-300 group-hover:stroke-none" stroke-width="6" />
+  </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"
+    class="h-8 w-8 transition hidden dark:block">
+    <rect x="3" y="3" width="94" height="94" stroke-width="6" rx="16" ry="16"
+      class='stroke-gray-400 fill-none group-hover:fill-gray-50'/>
+    <circle cx="50" cy="50" r="20" class="stroke-gray-400 fill-none group-hover:stroke-none group-hover:fill-amber-500" stroke-width="6" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(45, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(90, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(135, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(180, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(225, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(270, 50, 50)" />
+    <line x1="8" y1="50" x2="22" y2="50" class="stroke-gray-400 group-hover:stroke-amber-500" stroke-width="6" transform="rotate(315, 50, 50)" />
   </svg>
 </button>


### PR DESCRIPTION
This idea is from react official documentation website. https://react.dev/

The current mode is stored on client side, `localStorage`, so the server cannot identify which color theme is selected.
It is served prerendered anyway.

Prior to the PR, the button renders empty (null) button on server.
Then, scripts inside the component gets the current theme and update the rendered HTML.
That means there is a mismatch between the current theme and the rendered page.
When the client code updates, the page *flickers*.

https://github.com/user-attachments/assets/3185e5f4-b787-4362-9ade-4b957ffd8fbe

To prevent flickering, used `dark:` classes itself.
On dark mode, hide the dark mode button. Same goes with light mode.

```svelte
<button title="Click to activate dark mode" class="dark:hidden">

<button title="Click to toggle to light mode" class="hidden dark:block">
```