### PR TITLE
Fix `TOC` performance issue due to repeated `bind:offsetHeight`

### DIFF
--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+  import TocItemComponent from './TOCItemComponent.svelte';
   import type {TOCItem} from '$lib/types';
-  import {headingHighlight, tocItemHeight} from '$lib/store';
+  import {headingHighlight} from '$lib/store';
   import {showTOC} from '$lib/store';
   import {onMount} from 'svelte';
 
   export let data: TOCItem[];
 
-  const coefficient = 2 / 3;
-  const constant = 0.4;
 
   onMount(() => {
     $showTOC = false;
@@ -38,17 +37,8 @@ The scrollable height is not big enough to show the front child 'li' elements.
   ${$showTOC ? '!w-[94vw] py-6 z-20 !flex fixed top-14 left-[50%] translate-x-[-50%] border-2 border-neutral-300 bg-neutral-50 shadow-lg rounded-md dark:bg-neutral-800' : ''}`}>
   <div class="relative w-full overflow-auto max-h-[80vh]">
     <ul class="relative">
-      {#each data as item}
-        <!-- I would like to bind the height for the first li only, but do not know easy way to do that. -->
-        <li title={item.text} bind:offsetHeight={$tocItemHeight}
-          class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''} ${$showTOC ? 'py-1.5' : ''}
-        `}
-        >
-          <a href={`#${item.id}`} class="relative z-10 py-0.5 whitespace-nowrap overflow-hidden break-all overflow-ellipsis flex-grow"
-            style={`padding-left: ${coefficient * (item.depth - 1) + constant}rem;`}>
-            {item.text}
-          </a>
-        </li>
+      {#each data as item, ind}
+        <TocItemComponent item={item} shouldBind={ind === 0} />
       {/each}
       <div class="absolute top-0 left-0 z-5 rounded-xl bg-gray-200 dark:bg-gray-500/25 w-1 h-full" />
     </ul>

--- a/src/lib/components/TOCItemComponent.svelte
+++ b/src/lib/components/TOCItemComponent.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type {TOCItem} from '$lib/types';
+  import {tocItemHeight, showTOC} from '$lib/store';
+
+  export let item: TOCItem;
+  export let shouldBind: boolean;
+
+  const coefficient = 2 / 3;
+  const constant = 0.4;
+</script>
+{#if shouldBind}
+  <!-- The only difference is bind property -->
+  <li
+    title={item.text}
+    bind:offsetHeight={$tocItemHeight}
+    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''} ${$showTOC ? 'py-1.5' : ''}
+  `}
+  >
+    <a
+      href={`#${item.id}`}
+      class="relative z-10 py-0.5 whitespace-nowrap overflow-hidden break-all overflow-ellipsis flex-grow"
+      style={`padding-left: ${coefficient * (item.depth - 1) + constant}rem;`}
+    >
+      {item.text}
+    </a>
+  </li>
+{:else}
+  <li
+    title={item.text}
+    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''} ${$showTOC ? 'py-1.5' : ''}
+  `}
+  >
+    <a
+      href={`#${item.id}`}
+      class="relative z-10 py-0.5 whitespace-nowrap overflow-hidden break-all overflow-ellipsis flex-grow"
+      style={`padding-left: ${coefficient * (item.depth - 1) + constant}rem;`}
+    >
+      {item.text}
+    </a>
+  </li>
+{/if}


### PR DESCRIPTION
This was due to repeated `bind:offsetHeight` properties on each TOC item.

I would like to do it like conditionally attaching the value to that property,
but it seems like there was no way to do that in Svelte.
https://github.com/sveltejs/svelte/issues/4570

This I console log like this:
```svelte
  const start = performance.now();

  onMount(() => {
    $showTOC = false;
    const onResize = () => {
      // md: size
      if (window.innerWidth >= 840) {
        $showTOC = false;
      }
    };
    window.addEventListener('resize', onResize);
    console.log(performance.now() - start);
```

It reduces about from 1300 ms to 90ms.