### PR TITLE
[#65] Fix deploy Action not running

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on code-check completed on the default branch
   workflow_run:
-    workflows: ["code-check"]
+    workflows: ["Code Check"]
     types: [completed]
     branches: ["main"]
 


### PR DESCRIPTION
Related to #65 .
It seems like the `name:` property should be specified.