### PR TITLE
Fix conflict between TOC and footnote heading created by remark-gfm

### DIFF
--- a/src/lib/components/MainSection.svelte
+++ b/src/lib/components/MainSection.svelte
@@ -3,9 +3,6 @@
   import {headingHighlight, shouldShowTOCButton, tocItemHeight} from '$lib/store';
   import throttleWithLast from '$lib/throttleWithLast';
 
-  
-  
-  
   interface Props {
     /** Raw html in `string` type */
     html?: string | null;
@@ -25,6 +22,7 @@
 
   let mainHtml: HTMLElement | null = $state(null);
   const refreshInterval = 100;
+  const headingSelector = ':scope > h1, :scope > h2, :scope > h3, :scope > h4';
   let headings: Element[] = $state([]);
   const throttledUpdateHeadingHighlight = throttleWithLast(() => updateHeadingHighlight(), refreshInterval);
 
@@ -89,7 +87,7 @@
     $shouldShowTOCButton = true;
     $headingHighlight = null;
 
-    headings = [...mainHtml.querySelectorAll('h1,h2,h3,h4')];
+    headings = [...mainHtml.querySelectorAll(headingSelector)];
     document.addEventListener('scroll', throttledUpdateHeadingHighlight);
     return () => {
       $shouldShowTOCButton = false;
@@ -100,7 +98,7 @@
 
   $effect(() => {
     if ($tocItemHeight && mainHtml) {
-      headings = [...mainHtml.querySelectorAll('h1,h2,h3,h4')];
+      headings = [...mainHtml.querySelectorAll(headingSelector)];
       // Need to call update highlight function manually here for following situations:
       // However, calling the function right away may have undesirable effects because the height might change,
       // maybe due to images not loaded yet. Need to call after some interval.


### PR DESCRIPTION
remark-gfm creates `h2` footnote wrapped in a section element.

<kbd>
<img src="https://github.com/user-attachments/assets/fe52b9a0-4f95-4125-a0c0-442ad37e99e9">
</kbd>

While `getHtmlFromMarkdown`, which is responsible for creating `tocData` only searches root's children,
scripts in `MainSection` component which renders TOC highlight searches recursively, creating unwanted conflicts.

The solution is to edit heading selector to target direct child headings only.
