### PR TITLE
Fix TOC highlight not work on /categories and /tags pages

### DIFF
--- a/src/lib/components/MainSection.svelte
+++ b/src/lib/components/MainSection.svelte
@@ -22,7 +22,7 @@
 
   let mainHtml: HTMLElement | null = $state(null);
   const refreshInterval = 100;
-  const headingSelector = ':scope > h1, :scope > h2, :scope > h3, :scope > h4';
+  const headingSelector = 'h1:not(*[data-footnotes] *), h2:not(*[data-footnotes] *), h3:not(*[data-footnotes] *), h4:not(*[data-footnotes] *)';
   let headings: Element[] = $state([]);
   const throttledUpdateHeadingHighlight = throttleWithLast(() => updateHeadingHighlight(), refreshInterval);
 


### PR DESCRIPTION
This PR resolves an issue that was introduced by #71 .

Since /categories and /tags pages wrap heading elements in `section` elements,
those headings are not selected with the selector.
Fix selector not to grasp heading elements within footnote element. This will do the job as expected.