### PR TITLE
Reload `/post/[year]/[slug]` on markdown file change

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,3 +8,6 @@ export const postBasePath = './markdown';
 export const maxHeadingDepthInToc = 3;
 /** Language format should follow BCP 47. */
 export const defaultLang = 'en';
+export const customEvent = {
+  reload: 'custom:reload',
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,12 +4,29 @@
   import Header from './Header.svelte';
   import Overlay from '$lib/components/Overlay.svelte';
   import {shouldShowOverlay} from '$lib/store';
-  import {name} from '$lib/index';
+  import {onMount} from 'svelte';
+  import {customEvent, name} from '$lib/index';
+  import {page} from '$app/state';
+
   interface Props {
     children?: import('svelte').Snippet;
   }
 
   let {children}: Props = $props();
+
+  onMount(() => {
+    if (import.meta.hot) {
+      import.meta.hot.on(
+        customEvent.reload,
+        (payload: {path: string}) => {
+          if (page.url.pathname.startsWith(payload.path)) {
+            console.log(`${customEvent.reload} activated...`);
+            window.location.reload();
+          }
+        }
+      );
+    }
+  });
 </script>
 <svelte:head>
   <title>{name}'s blog</title>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import {sveltekit} from '@sveltejs/kit/vite';
 import {defineConfig, type PluginOption, type WebSocketServer} from 'vite';
 import {customEvent} from './src/lib';
 
-/** Handle /posts/[slug]. */
+/** Handle /posts/[year]/[slug] on markdown file change. */
 const handlePostPage = (filePath: string, {ws}: {ws: WebSocketServer}) => {
   const markdownFilePathRegex = /(\d+\/\d+-\d+-[a-z]{2}-[^.]+)\.md$/;
   const matchResult = filePath.match(markdownFilePathRegex);


### PR DESCRIPTION
post page will be reloaded on the corresponding markdown file change.

I tried to use `full-reload` event rather than custom event, but it simply does not work to reload on selected url path.
https://github.com/vitejs/vite/issues/5763

Thus for simplicity and modularity I created a custom event and watch the payload.