### PR TITLE
Fix Dart legacy API deprecated warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,4 +40,14 @@ export default defineConfig({
     sveltekit(),
     reloadPlugin()
   ],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // This specification not needed after migrating to Vite 6.
+        // https://sass-lang.com/documentation/breaking-changes/legacy-js-api/
+        // https://v5.vite.dev/config/shared-options.html#css-preprocessoroptions
+        api: 'modern-compiler',
+      },
+    },
+  },
 });


### PR DESCRIPTION
This config will resolve the following deprecation warning from console output.
```
More info: https://sass-lang.com/d/legacy-js-api
Deprecation [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
```

https://sass-lang.com/documentation/breaking-changes/legacy-js-api/
https://v5.vite.dev/config/shared-options.html#css-preprocessoroptions