### PR TITLE
Fix comment appears in markdown

### DIFF
--- a/src/routes/Markdowner.svelte
+++ b/src/routes/Markdowner.svelte
@@ -35,7 +35,9 @@
     {/if}
   {/if}
 {:else if 'value' in node}
-  {node.value}
+  {#if node.type !== 'comment'}
+    {node.value}
+  {/if}
 {:else}
   {@render Child()}
 {/if}


### PR DESCRIPTION
a comment node looks like below:
```js
{
    "type": "comment",
    "value": "\n{% highlight python linenos %}\n{% endhighlight %}\n ",
    "position": {
        "start": {
            "line": 156,
            "column": 1,
            "offset": 6095
        },
        "end": {
            "line": 159,
            "column": 5,
            "offset": 6154
        }
    }
}
```