### PR TITLE
Remove unused html property from getHtmlFromMarkdown

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -149,8 +149,7 @@ export const getHtmlFromMarkdown = async (markdown: string, includeToc: boolean)
     });
   }
 
-  const html = compiler.stringify(root);
-  return {html: String(html), tocData: includeToc ? headings : [], root};
+  return {tocData: includeToc ? headings : [], root};
 };
 
 const visitConvertHastNodePropertiesIntoHtml = (node: Parent | HastRootContent) => {

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -14,8 +14,8 @@ export const load = async () => {
     error(404);
   }
   try {
-    const {html, root} = await getHtmlFromMarkdown(rawContent, false);
-    return {html, root};
+    const {root} = await getHtmlFromMarkdown(rawContent, false);
+    return {root};
   } catch (e) {
     console.error(e);
     error(500);

--- a/src/routes/post/[year]/[slug]/+page.server.ts
+++ b/src/routes/post/[year]/[slug]/+page.server.ts
@@ -23,9 +23,9 @@ export const load: PageServerLoad = async ({params}) => {
   try {
     const {date, lang, id} = getDateLangIdFromPostPath(postFilePath);
     const frontmatter = await getFrontmatterFromMarkdown<Frontmatter>(rawContent);
-    const {html, root, tocData} = await getHtmlFromMarkdown(rawContent, !!frontmatter?.toc);
+    const {root, tocData} = await getHtmlFromMarkdown(rawContent, !!frontmatter?.toc);
     const langs = await getAvailableLanguagesOfPost(postFilePath);
-    return {html, root, frontmatter, date, lang, id, tocData, langs};
+    return {root, frontmatter, date, lang, id, tocData, langs};
   } catch (e) {
     console.error(e);
     error(500);


### PR DESCRIPTION
Removed relics from rendering with raw HTML (related with #89)

output `build` folder size: `35.4MiB` -> `32.9MiB`