### PR TITLE
Show language in CodeBlock

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -63,7 +63,7 @@ export const getSummaryFromMarkdown = async (markdown: string, targetLength: num
 /**
  * Extract frontmatter from markdown.
  */
-export const getFrontmatterFromMarkdown = async <T> (markdown: string) => {
+export const getFrontmatterFromMarkdown = async <T>(markdown: string) => {
   let frontmatter = null;
   await unified()
     .use(remarkParse)

--- a/src/routes/CodeBlock.svelte
+++ b/src/routes/CodeBlock.svelte
@@ -5,10 +5,19 @@
   }
   let preElement: HTMLPreElement;
   let {children, preProperties}: Props = $props();
-  const language =
-    (typeof preProperties?.class === 'string' && preProperties.class.match(/^language-/))
-      ? preProperties.class.replace(/^language-/, '')
-      : undefined;
+
+  const getLanguage = () => {
+    if (typeof preProperties?.class !== 'string') {
+      return undefined;
+    }
+    const match = preProperties.class.match(/language-(\w+)/);
+    if (match === null) {
+      return undefined;
+    }
+    return match[1];
+  };
+  const language = getLanguage();
+
   const copy = () => {
     try {
       if (!preElement.textContent) {

--- a/src/routes/CodeBlock.svelte
+++ b/src/routes/CodeBlock.svelte
@@ -5,6 +5,10 @@
   }
   let preElement: HTMLPreElement;
   let {children, preProperties}: Props = $props();
+  const language =
+    (typeof preProperties?.class === 'string' && preProperties.class.match(/^language-/))
+      ? preProperties.class.replace(/^language-/, '')
+      : undefined;
   const copy = () => {
     try {
       if (!preElement.textContent) {
@@ -18,7 +22,11 @@
 </script>
 <div class="overflow-hidden border border-gray-300 dark:border-gray-700 rounded-md my-2">
   <div class="border-b border-gray-300 dark:border-gray-700 flex flex-row justify-between px-2 py-1">
-    <div class="w-0 h-0"></div>
+    <div class="flex items-center font-mono text-sm">
+      {#if language !== undefined}
+        {language}
+      {/if}
+    </div>
     <button onclick={copy} class="px-2 py-1 rounded-md text-sm bg-slate-100 dark:bg-slate-700 text-black dark:text-white hover:bg-slate-200 dark:hover:bg-slate-500 active:bg-emerald-300 dark:active:bg-emerald-400">Copy</button>
   </div>
   <!-- [NOTE] whitespaces within pre tag are render as-is even the indentations within the tag. -->


### PR DESCRIPTION
Shows what language the code block is written in.

code blocks in hast node form have `language-{lang}` in their class property.