### PR TITLE
Fix and Improve TOC

### DIFF
--- a/src/lib/components/MainSection.svelte
+++ b/src/lib/components/MainSection.svelte
@@ -109,7 +109,7 @@
     // This is most likely due to Svelte not recreating elements thus not running logics.
     // Thus depend on root props for reactivity.
     // See: https://github.com/dlguswo333/dlguswo333.github.io/issues/44
-    if ($tocItemHeight && mainHtml && root) {
+    if ($tocItemHeight && mainHtml) {
       headings = [...mainHtml.querySelectorAll(headingSelector)];
       // Need to call update highlight function manually here for following situations:
       // However, calling the function right away may have undesirable effects because the height might change,

--- a/src/lib/components/TOC.svelte
+++ b/src/lib/components/TOC.svelte
@@ -39,18 +39,20 @@ The scrollable height is not big enough to show the front child 'li' elements.
 -->
 <aside class={`w-[330px] overflow-hidden hidden mt-10 self-start md:!flex md:sticky md:top-14 flex-col justify-center items-center p-3
   ${$showTOC ? '!w-[94vw] py-6 z-20 !flex fixed top-14 left-[50%] translate-x-[-50%] border-2 border-neutral-300 bg-neutral-50 shadow-lg rounded-md dark:bg-neutral-800' : ''}`}>
-  <div class="relative w-full overflow-auto max-h-[80vh]">
-    <ul class="relative">
-      {#each data as item, ind}
-        <TocItemComponent item={item} shouldBind={ind === 0} />
-      {/each}
+  <div class="w-full overflow-auto max-h-[80vh]">
+    <div class="relative">
+      <ul>
+        {#each data as item, ind}
+          <TocItemComponent item={item} shouldBind={ind === 0} />
+        {/each}
+      </ul>
       <div class="absolute top-0 left-0 z-5 rounded-xl bg-gray-200 dark:bg-gray-500/25 w-1 h-full"></div>
-    </ul>
-    {#if highlightTop !== undefined && highlightBottom !== undefined}
-      <div class={'absolute left-0 flex'} style={`transition: top 0.1s ease-out, height 0.1s ease-out; top: ${highlightTop}px; height:${highlightBottom - highlightTop}px`}>
-        <div class="z-10 rounded-xl bg-blue-400 dark:bg-purple-500 w-1 h-full"></div>
-        <div class="z-5 absolute left-0.5 w-6 h-full bg-gradient-to-r from-blue-100 dark:from-fuchsia-900 to-transparent"></div>
-      </div>
-    {/if}
+      {#if highlightTop !== undefined && highlightBottom !== undefined}
+        <div class={'absolute left-0 flex'} style={`transition: top 0.1s ease-out, height 0.1s ease-out; top: ${highlightTop}px; height:${highlightBottom - highlightTop}px`}>
+          <div class="z-10 rounded-xl bg-blue-400 dark:bg-purple-500 w-1 h-full"></div>
+          <div class="z-5 absolute left-0.5 w-6 h-full bg-gradient-to-r from-blue-100 dark:from-fuchsia-900 to-transparent"></div>
+        </div>
+      {/if}
+    </div>
   </div>
 </aside>

--- a/src/lib/components/TOCItemComponent.svelte
+++ b/src/lib/components/TOCItemComponent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type {TOCItem} from '$lib/types';
-  import {tocItemHeight, showTOC} from '$lib/store';
+  import {tocItemHeight} from '$lib/store';
 
   interface Props {
     item: TOCItem;
@@ -15,7 +15,7 @@
 {#snippet anchor()}
   <a
     href={`#${item.id}`}
-    class="relative z-10 py-0.5 whitespace-nowrap overflow-hidden break-all overflow-ellipsis flex-grow"
+    class="relative z-10 py-1.5 whitespace-nowrap overflow-hidden break-all overflow-ellipsis flex-grow"
     style={`padding-left: ${coefficient * (item.depth - 1) + constant}rem;`}
   >
     {item.text}
@@ -25,7 +25,7 @@
   <!-- The only difference is bind property -->
   <li
     title={item.text}
-    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''} ${$showTOC ? 'py-1.5' : ''}`}
+    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''}`}
     bind:offsetHeight={$tocItemHeight}
   >
     {@render anchor()}
@@ -33,7 +33,7 @@
 {:else}
   <li
     title={item.text}
-    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''} ${$showTOC ? 'py-1.5' : ''}`}
+    class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''}`}
   >
     {@render anchor()}
   </li>

--- a/src/lib/components/TOCItemComponent.svelte
+++ b/src/lib/components/TOCItemComponent.svelte
@@ -8,9 +8,17 @@
   }
 
   let {item, shouldBind}: Props = $props();
+  let tocItem: HTMLElement | null = $state(null);
 
   const coefficient = 2 / 3;
   const constant = 0.4;
+
+  $effect(() => {
+    if (tocItem === null) {
+      return;
+    }
+    $tocItemHeight = tocItem.getBoundingClientRect().height;
+  });
 </script>
 {#snippet anchor()}
   <a
@@ -26,7 +34,7 @@
   <li
     title={item.text}
     class={`flex ml-1 hover:bg-gray-100 dark:hover:bg-gray-700 ${item.depth === 1 ? 'font-bold' : ''}`}
-    bind:offsetHeight={$tocItemHeight}
+    bind:this={tocItem}
   >
     {@render anchor()}
   </li>


### PR DESCRIPTION
- Make each item bigger for UX.
- Fix highlight not updated on mount on page without root node property (e.g. tag page on page refresh).
- Fix ul > li structure. `div` bar had been inside the ul.
- Fix highlight element overflow container. This is due to `offsetHeight` rounds to integers ([link](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements#how_much_room_does_it_use_up))