### PR TITLE
[#113] Group same posts written in different languages together in post list

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -21,18 +21,18 @@
 {/snippet}
 
 <section
-  class={`flex flex-col px-4 py-3 md:py-2 transition border rounded-md hover:bg-teal-50 dark:hover:bg-teal-700/20
+  class={`flex flex-col px-4 py-4 md:py-3 transition border rounded-md hover:bg-teal-50 dark:hover:bg-teal-700/20
     border-gray-200 hover:border-teal-200 dark:border-gray-600 dark:hover:border-teal-600
     shadow-sm hover:shadow-md shadow-gray-300 dark:shadow-gray-900 dark:hover:shadow-teal-900/50`}>
-  <div class="flex flex-col md:flex-row items-start md:items-center justify-between">
+  <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-1">
     <div class="inline-block">
-      <h2 class="font-bold text-lg underline">
+      <h2 class="font-bold text-xl underline">
         {@render Anchor(getPostUrl(indexPost), indexPost.title)}
       </h2>
       {#if posts.length > 1}
         {#each posts as post}
           {#if post.lang !== indexLanguage}
-            <h3 class="font-bold text-sm underline">
+            <h3 class="font-bold text-base underline">
               {@render Anchor(getPostUrl(post), post.title)}
             </h3>
           {/if}
@@ -51,9 +51,9 @@
           {#each posts as post}
             <button
               class={
-                `transition px-2 py-0.5 rounded-md [&:not(:last-child)]:mr-1
-               hover:bg-lime-200 active:bg-lime-300 dark:hover:bg-slate-600 dark:active:bg-teal-800
-                ${indexLanguage === post.lang ? 'underline' : ''}`
+                `transition px-2 py-1 md:py-0.5 rounded-md [&:not(:last-child)]:mr-2
+               hover:bg-gray-300 active:bg-lime-200 dark:hover:bg-slate-600 dark:active:bg-teal-800
+                ${indexLanguage === post.lang ? 'underline bg-gray-200/50 dark:bg-gray-700/60' : ''}`
               }
               type="button"
               onclick={() => indexLanguage = post.lang}

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -1,57 +1,94 @@
 <script lang="ts">
+  import {defaultLang} from '$lib/index';
   import Tag from '$lib/components/Tag.svelte';
   import type {PostMetadata} from '$lib/types';
   import Category from './Category.svelte';
 
   interface Props {
-    post: PostMetadata;
+    posts: PostMetadata[];
   }
 
-  let {post}: Props = $props();
+  const {posts}: Props = $props();
+  let indexLanguage = $derived((posts.find(({lang}) => lang === defaultLang) ?? posts[0]).lang);
+  const indexPost = $derived(posts.find(({lang}) => lang === indexLanguage))!;
+  const getPostUrl = (post: PostMetadata) => `/post/${post.date.split('-')[0]}/${post.id}/`;
 </script>
 
 <section
   class={`flex flex-col px-4 py-3 md:py-2 transition border rounded-md hover:bg-teal-50 dark:hover:bg-teal-700/20
     border-gray-200 hover:border-teal-200 dark:border-gray-600 dark:hover:border-teal-600
     shadow-sm hover:shadow-md shadow-gray-300 dark:shadow-gray-900 dark:hover:shadow-teal-900/50`}>
-  <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-1">
+  <div class="flex flex-col md:flex-row items-start md:items-center justify-between">
     <div class="inline-block">
       <h2 class="inline-block font-bold text-lg underline">
-        <a href={`/post/${post.date.split('-')[0]}/${post.id}/`}
+        <a href={getPostUrl(indexPost)}
           class="text-sky-500 visited:text-purple-600 hover:brightness-125 active:brightness-150 mr-2">
-          {post.title}
+          {indexPost.title}
         </a>
       </h2>
     </div>
-    <span class="text-sm flex flex-row self-stretch justify-between">
-      <span class="">
-        {post.date}
-        {#if post.editedDate}
-          (Edit {post.editedDate})
+    <span class="text-sm flex flex-row self-stretch justify-between items-center">
+      <span>
+        {indexPost.date}
+        {#if indexPost.editedDate}
+          (Edit {indexPost.editedDate})
         {/if}
       </span>
       <span class="ml-2">
-        {post.lang}
+        {#if posts.length > 1}
+          {#each posts as post}
+            <button
+              class={
+                `transition px-2 py-0.5 rounded-md [&:not(:last-child)]:mr-1
+               hover:bg-lime-200 active:bg-lime-300 dark:hover:bg-slate-600 dark:active:bg-teal-800
+                ${indexLanguage === post.lang ? 'underline' : ''}`
+              }
+              type="button"
+              onclick={() => indexLanguage = post.lang}
+            >
+              {post.lang}
+            </button>
+          {/each}
+        {:else}
+          {indexLanguage}
+        {/if}
       </span>
     </span>
   </div>
+  {#if posts.length > 1}
+    <!-- [TODO] Move right below the index title -->
+    <div class="mb-1">
+      {#each posts as post}
+        {#if post.lang !== indexLanguage}
+          <div>
+            <h3 class="inline-block text-sm font-bold underline">
+              <!-- [TODO] Extract into snippet -->
+              <a href={getPostUrl(post)} class="text-sky-500 visited:text-purple-600 hover:brightness-125 active:brightness-150 mr-2">
+                {post.title}
+              </a>
+            </h3>
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
   <div>
     <span>
-      {#if post.category}
-        <Category categoryName={post.category} />
+      {#if indexPost.category}
+        <Category categoryName={indexPost.category} />
       {/if}
       <span>
-        {#if post.tags}
-          {#each post.tags as tag, index}
+        {#if indexPost.tags}
+          {#each indexPost.tags as tag, index}
             <Tag tagName={tag} marginLeft={index === 0 ? 2 : 0} marginRight={1} />
           {/each}
         {/if}
       </span>
     </span>
   </div>
-  {#if post.summary}
+  {#if indexPost.summary}
     <div class="mt-4" style={'overflow-wrap: anywhere;'}>
-      {post.summary}
+      {indexPost.summary}
     </div>
   {/if}
 </section>

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -26,11 +26,20 @@
     shadow-sm hover:shadow-md shadow-gray-300 dark:shadow-gray-900 dark:hover:shadow-teal-900/50`}>
   <div class="flex flex-col md:flex-row items-start md:items-center justify-between">
     <div class="inline-block">
-      <h2 class="inline-block font-bold text-lg underline">
+      <h2 class="font-bold text-lg underline">
         {@render Anchor(getPostUrl(indexPost), indexPost.title)}
       </h2>
+      {#if posts.length > 1}
+        {#each posts as post}
+          {#if post.lang !== indexLanguage}
+            <h3 class="font-bold text-sm underline">
+              {@render Anchor(getPostUrl(post), post.title)}
+            </h3>
+          {/if}
+        {/each}
+      {/if}
     </div>
-    <span class="text-sm flex flex-row self-stretch justify-between items-center">
+    <div class="text-sm flex flex-row self-stretch md:self-start justify-between items-center">
       <span>
         {indexPost.date}
         {#if indexPost.editedDate}
@@ -56,22 +65,8 @@
           {indexLanguage}
         {/if}
       </span>
-    </span>
-  </div>
-  {#if posts.length > 1}
-    <!-- [TODO] Move right below the index title -->
-    <div class="mb-1">
-      {#each posts as post}
-        {#if post.lang !== indexLanguage}
-          <div>
-            <h3 class="inline-block text-sm font-bold underline">
-              {@render Anchor(getPostUrl(post), post.title)}
-            </h3>
-          </div>
-        {/if}
-      {/each}
     </div>
-  {/if}
+  </div>
   <div>
     <span>
       {#if indexPost.category}

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -27,7 +27,7 @@
       <span class="">
         {post.date}
         {#if post.editedDate}
-          (E. {post.editedDate})
+          (Edit {post.editedDate})
         {/if}
       </span>
       <span class="ml-2">

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -14,6 +14,12 @@
   const getPostUrl = (post: PostMetadata) => `/post/${post.date.split('-')[0]}/${post.id}/`;
 </script>
 
+{#snippet Anchor(href: string, text: string)}
+  <a href={href} class="text-sky-500 visited:text-purple-600 hover:brightness-125 active:brightness-150 mr-2">
+    {text}
+  </a>
+{/snippet}
+
 <section
   class={`flex flex-col px-4 py-3 md:py-2 transition border rounded-md hover:bg-teal-50 dark:hover:bg-teal-700/20
     border-gray-200 hover:border-teal-200 dark:border-gray-600 dark:hover:border-teal-600
@@ -21,10 +27,7 @@
   <div class="flex flex-col md:flex-row items-start md:items-center justify-between">
     <div class="inline-block">
       <h2 class="inline-block font-bold text-lg underline">
-        <a href={getPostUrl(indexPost)}
-          class="text-sky-500 visited:text-purple-600 hover:brightness-125 active:brightness-150 mr-2">
-          {indexPost.title}
-        </a>
+        {@render Anchor(getPostUrl(indexPost), indexPost.title)}
       </h2>
     </div>
     <span class="text-sm flex flex-row self-stretch justify-between items-center">
@@ -62,10 +65,7 @@
         {#if post.lang !== indexLanguage}
           <div>
             <h3 class="inline-block text-sm font-bold underline">
-              <!-- [TODO] Extract into snippet -->
-              <a href={getPostUrl(post)} class="text-sky-500 visited:text-purple-600 hover:brightness-125 active:brightness-150 mr-2">
-                {post.title}
-              </a>
+              {@render Anchor(getPostUrl(post), post.title)}
             </h3>
           </div>
         {/if}

--- a/src/lib/components/PostList.svelte
+++ b/src/lib/components/PostList.svelte
@@ -5,18 +5,18 @@
   import PostCard from './PostCard.svelte';
 
   interface Props {
-    posts: PostMetadata[];
+    groupedPosts: PostMetadata[][];
     curIndex: number;
     maxIndex: number;
   }
 
-  let {posts, curIndex, maxIndex}: Props = $props();
+  let {groupedPosts, curIndex, maxIndex}: Props = $props();
 </script>
 <MainSection className="flex flex-col items-center pb-3">
   <ul class="py-4">
-    {#each posts as post}
+    {#each groupedPosts as posts}
       <li class="mb-5 last:mb-0 px-4">
-        <PostCard post={post} />
+        <PostCard posts={posts} />
       </li>
     {/each}
   </ul>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,15 +1,15 @@
 import {paginationSize} from '$lib';
-import crawlPosts from '$lib/crawlPosts';
+import crawlPosts, {groupPostsByTopic} from '$lib/crawlPosts';
 
 export const load = async () => {
-  const posts = await crawlPosts();
+  const groupedPosts = groupPostsByTopic(await crawlPosts());
   const curIndex = 1;
   const start = (curIndex - 1) * paginationSize;
   const end = curIndex * paginationSize;
-  const paginatedPosts = posts.slice(start, end);
+  const paginatedPosts = groupedPosts.slice(start, end);
   return {
-    posts: paginatedPosts,
+    groupedPosts: paginatedPosts,
     curIndex: curIndex,
-    maxIndex: Math.ceil(posts.length / paginationSize),
+    maxIndex: Math.ceil(groupedPosts.length / paginationSize),
   };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 </script>
 <div class="flex flex-row flex-grow justify-center lg:pr-[300px]">
   <Profile />
-  <PostList posts={data.posts} curIndex={data.curIndex} maxIndex={data.maxIndex} />
+  <PostList groupedPosts={data.groupedPosts} curIndex={data.curIndex} maxIndex={data.maxIndex} />
   <!-- Placeholder element -->
   <div class="max-w-[300px]"></div>
 </div>

--- a/src/routes/posts/[slug]/+page.server.ts
+++ b/src/routes/posts/[slug]/+page.server.ts
@@ -1,19 +1,19 @@
 import {paginationSize} from '$lib';
-import crawlPosts from '$lib/crawlPosts';
+import crawlPosts, {groupPostsByTopic} from '$lib/crawlPosts';
 import {error, type Load} from '@sveltejs/kit';
 
 export const load: Load = async ({params}) => {
-  const posts = await crawlPosts();
+  const groupedPosts = groupPostsByTopic(await crawlPosts());
   const curIndex = Number(params.slug);
   if (Number.isNaN(curIndex) || !Number.isInteger(curIndex) || curIndex <= 0) {
     error(404);
   }
   const start = (curIndex - 1) * paginationSize;
   const end = curIndex * paginationSize;
-  const paginatedPosts = posts.slice(start, end);
+  const paginatedPosts = groupedPosts.slice(start, end);
   return {
-    posts: paginatedPosts,
+    groupedPosts: paginatedPosts,
     curIndex: curIndex,
-    maxIndex: Math.ceil(posts.length / paginationSize),
+    maxIndex: Math.ceil(groupedPosts.length / paginationSize),
   };
 };

--- a/src/routes/posts/[slug]/+page.svelte
+++ b/src/routes/posts/[slug]/+page.svelte
@@ -16,5 +16,5 @@
   <title>{name}'s blog - page {data.curIndex}</title>
 </svelte:head>
 <div class="flex flex-row flex-grow justify-center lg:pr-20">
-  <PostList posts={data.posts} curIndex={data.curIndex} maxIndex={data.maxIndex} />
+  <PostList groupedPosts={data.groupedPosts} curIndex={data.curIndex} maxIndex={data.maxIndex} />
 </div>


### PR DESCRIPTION
Closes #113.

<img width="791" height="242" alt="image" src="https://github.com/user-attachments/assets/35759332-4bf0-45b3-96c7-3840724b4b91" />

- Group posts about the same topic in different languages.
- Show available languages.
- Clicking a button switches the post card to the language.
- Show links with post titles in other languages for direct access.
- Improve styles: some spacings.