### PR TITLE
Apply FileBasedCache on crawlPosts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,10 +13,6 @@ export type PostMetadata = Frontmatter & {
   id: string;
 }
 
-export type CachedPostMetadata = PostMetadata & {
-  crawledTimestamp: number;
-}
-
 export type TOCItem = {
   text: string;
   depth: number;


### PR DESCRIPTION
:warning: This is a breaking change; old `.posts.json` is not compatible with `FileBasedCache`.
The old file needs to be deleted so that `FileBasedCache` writes a complete new cache file.