### PR TITLE
[#126] Fix issues with `page.url.origin` not work with prerendered outputs (og:image, hreflang)

### DIFF
--- a/src/routes/post/[year]/[slug]/+page.svelte
+++ b/src/routes/post/[year]/[slug]/+page.svelte
@@ -4,7 +4,7 @@
   import TOC from '$lib/components/TOC.svelte';
   import Tag from '$lib/components/Tag.svelte';
   import {onMount} from 'svelte';
-  import {defaultLang, defaultOgImageUrl, defaultTitle, name} from '$lib/index';
+  import {blogFullUrl, defaultLang, defaultOgImageUrl, defaultTitle, name} from '$lib/index';
   import Lang from '$lib/components/Lang.svelte';
   import {afterNavigate} from '$app/navigation';
   import {page} from '$app/state';
@@ -20,7 +20,7 @@
     if (/^https?:/.test(url)) {
       return url;
     }
-    return new URL(url, page.url.origin).toString();
+    return new URL(url, blogFullUrl).toString();
   });
   let postAvailableLangs = $derived(data.langs);
   let getPostPathWithLang = (lang: string) => `/post/${data.date.split('-')[0]}/${data.id.replace(postLang, lang)}/`;

--- a/src/routes/post/[year]/[slug]/+page.svelte
+++ b/src/routes/post/[year]/[slug]/+page.svelte
@@ -7,7 +7,6 @@
   import {blogFullUrl, defaultLang, defaultOgImageUrl, defaultTitle, name} from '$lib/index';
   import Lang from '$lib/components/Lang.svelte';
   import {afterNavigate} from '$app/navigation';
-  import {page} from '$app/state';
 
   let {data} = $props();
 
@@ -45,7 +44,7 @@
   <title>{(postTitle ? `${postTitle} | ` : '')}{name}'s blog</title>
   {#if postAvailableLangs.length > 1}
     {#each postAvailableLangs as lang (lang)}
-      <link rel="alternate" hreflang={lang} href={new URL(getPostPathWithLang(lang), page.url.origin).toString()} />
+      <link rel="alternate" hreflang={lang} href={new URL(getPostPathWithLang(lang), blogFullUrl).toString()} />
     {/each}
   {/if}
   {#if postOgImage}


### PR DESCRIPTION
Related with #126 not working on production.
The below is the source html provided by web server. It can't work without hydration.
For instance It does not work with https://www.opengraph.io/og-test.

```html
<link rel="alternate" hreflang="ko" href="http://sveltekit-prerender/post/2025/12-27-ko-ortisei-dolomites-travel/"/>
<meta property="og:image" content="http://sveltekit-prerender/img/2025-12-27-ortisei-dolomites-travel/seceda-0.webp"/>
```